### PR TITLE
Bug Fix: Fix typos in macro definitions

### DIFF
--- a/npkit_for_nccl_v2.10.3-1/src/collectives/device/prims_ll128.h.diff
+++ b/npkit_for_nccl_v2.10.3-1/src/collectives/device/prims_ll128.h.diff
@@ -242,13 +242,13 @@ index 439072e..68e1f63 100644
 +    }
 +#endif
 +    GenericOp<1, 0, -1, Output>(-1, outIx, eltN, postOp);
-+#if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_NPKIT_EVENT_RECV_EXIT)
++#if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_EXIT)
 +#if defined(ENABLE_NPKIT_THREAD_SPLIT_SECOND_HALF)
 +    if (threadIdx.x != 0 && tid == 0) {
 +#else
 +    if (threadIdx.x == 0) {
 +#endif
-+      NpKit::GenerateAndCollectGpuEvent(NPKIT_NPKIT_EVENT_RECV_EXIT, eltN*sizeof(T), 0, clock64(),
++      NpKit::GenerateAndCollectGpuEvent(NPKIT_EVENT_RECV_EXIT, eltN*sizeof(T), 0, clock64(),
 +          &(ncclShmem.channel.npKitEvent), ncclShmem.channel.gpuNpKitEventCollectContext);
 +    }
 +#endif

--- a/npkit_for_rccl_develop_4643a17/src/collectives/device/prims_ll128.h.diff
+++ b/npkit_for_rccl_develop_4643a17/src/collectives/device/prims_ll128.h.diff
@@ -242,13 +242,13 @@ index 81753a0..354ff7a 100644
 +    }
 +#endif
 +    GenericOp<1, 0, -1, Output>(-1, outIx, eltN, postOp);
-+#if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_NPKIT_EVENT_RECV_EXIT)
++#if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_EXIT)
 +#if defined(ENABLE_NPKIT_THREAD_SPLIT_SECOND_HALF)
 +    if (threadIdx.x != 0 && tid == 0) {
 +#else
 +    if (threadIdx.x == 0) {
 +#endif
-+      NpKit::GenerateAndCollectGpuEvent(NPKIT_NPKIT_EVENT_RECV_EXIT, eltN*sizeof(T), 0, __builtin_amdgcn_s_memrealtime(),
++      NpKit::GenerateAndCollectGpuEvent(NPKIT_EVENT_RECV_EXIT, eltN*sizeof(T), 0, __builtin_amdgcn_s_memrealtime(),
 +          &(ncclShmem->channel.npKitEvent), ncclShmem->channel.gpuNpKitEventCollectContext);
 +    }
 +#endif


### PR DESCRIPTION
This commit fixes some typos in macro definitions.